### PR TITLE
releasetool: add OSIP partitions specifics

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -1402,7 +1402,8 @@ PARTITION_TYPES = {
     "squashfs": "EMMC",
     "ext2": "EMMC",
     "ext3": "EMMC",
-    "vfat": "EMMC"
+    "vfat": "EMMC",
+    "osip": "OSIP"
 }
 
 def GetTypeAndDevice(mount_point, info):

--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -323,6 +323,10 @@ class EdifyGenerator(object):
         self.script.append(
             'write_raw_image(package_extract_file("%(fn)s"), "%(device)s");'
             % args)
+      elif partition_type == "OSIP":
+        self.script.append(
+            'write_osip_image(package_extract_file("%(fn)s"), "%(device)s");'
+            % args)
       elif partition_type == "EMMC":
         if mapfn:
           args["map"] = mapfn


### PR DESCRIPTION
- Declare OSIP as a new partition type
- Standard boot.img update is not possible for OSIP partitions
We are simply removing it on AOSP handling, and let the board handle
it in its own releasetool.py

Change-Id: Ie19fc3f6a0ca42e2eda264904b20fceeddbeaf53